### PR TITLE
chore: add alternate way to set config values

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ npm i @tractorzoom/serverless-mysql-utils
 
 ##### Usage:
 
-The following environment variables must be set to make the connection with mysql:
+The following environment variables must be set or a config object must be passed as a second arg to `executeQuery` to make the connection with mysql:
 | variable | type | description |
 | --------- | ------ | ------------------------------- |
 | database | string | mame of the database to use for this connection |
@@ -27,17 +27,18 @@ The following environment variables must be set to make the connection with mysq
 | password | string | the password of that mysql user |
 
 ```js
-import { executeQuery } from "@tractorzoom/serverless-mysql-utils";
+import dbConfig from './config';
+import { executeQuery } from '@tractorzoom/serverless-mysql-utils';
 
 export const getItems = async () => {
-  const queryString = `SELECT * FROM MyTable WHERE id = "some-guid"`;
+    const queryString = `SELECT * FROM MyTable WHERE id = "some-guid"`;
 
-  const response = await executeQuery(queryString);
+    const response = await executeQuery(queryString, dbConfig);
 
-  if (response.error) {
-    return [];
-  }
+    if (response.error) {
+        return [];
+    }
 
-  return response;
+    return response;
 };
 ```

--- a/__mocks__/serverless-mysql.js
+++ b/__mocks__/serverless-mysql.js
@@ -1,10 +1,13 @@
+const config = jest.fn();
 const end = jest.fn();
 const query = jest.fn();
 
+exports.config = config;
 exports.end = end;
 exports.query = query;
 
 module.exports = () => ({
-  query,
-  end
+    config,
+    end,
+    query,
 });

--- a/__tests__/execute-query.spec.js
+++ b/__tests__/execute-query.spec.js
@@ -1,69 +1,87 @@
-import Chance from "chance";
-import Mysql from "serverless-mysql";
-import executeQuery from "../src/execute-query";
+import Chance from 'chance';
+import Mysql from 'serverless-mysql';
+import executeQuery from '../src/execute-query';
 
 const chance = new Chance();
 const mysql = Mysql();
 
-jest.mock("serverless-mysql");
+jest.mock('serverless-mysql');
 
-describe("serverless mysql utility", () => {
-  let mockData;
+describe('serverless mysql utility', () => {
+    let mockData;
 
-  beforeEach(() => {
-    const rejectError = chance.string();
+    beforeEach(() => {
+        const rejectError = chance.string();
 
-    mockData = {
-      errorMessage: { error: `Error: ${rejectError}` },
-      query: chance.string(),
-      queryResponse: chance.string(),
-      rejectError
-    };
+        mockData = {
+            errorMessage: { error: `Error: ${rejectError}` },
+            query: chance.string(),
+            queryResponse: chance.string(),
+            rejectError,
+        };
 
-    mysql.query.mockResolvedValue(mockData.queryResponse);
-  });
+        mysql.query.mockResolvedValue(mockData.queryResponse);
+    });
 
-  afterEach(() => {
-    mysql.end.mockRestore();
-    mysql.query.mockRestore();
-  });
+    afterEach(() => {
+        mysql.config.mockRestore();
+        mysql.end.mockRestore();
+        mysql.query.mockRestore();
+    });
 
-  it("should successfully query mysql on the first try", async () => {
-    const response = await executeQuery(mockData.query);
+    it('should configure mysql when the option is passed', async () => {
+        // given
+        const dbConfig = {
+            host: chance.word(),
+            user: chance.word(),
+            password: chance.word(),
+            database: chance.word(),
+        };
 
-    expect(mysql.query).toHaveBeenCalledTimes(1);
-    expect(mysql.query).toHaveBeenCalledWith(mockData.query);
+        // when
+        await executeQuery(mockData.query, dbConfig);
 
-    expect(response).toEqual(mockData.queryResponse);
-  });
+        // then
+        expect(mysql.config).toHaveBeenCalledTimes(1);
+        expect(mysql.config).toHaveBeenCalledWith(dbConfig);
+    });
 
-  it("should fail the first query and succeed on the second", async () => {
-    mysql.query.mockRejectedValueOnce(new Error(mockData.rejectError));
+    it('should successfully query mysql on the first try', async () => {
+        const response = await executeQuery(mockData.query);
 
-    const response = await executeQuery(mockData.query);
+        expect(mysql.query).toHaveBeenCalledTimes(1);
+        expect(mysql.query).toHaveBeenCalledWith(mockData.query);
 
-    expect(mysql.query).toHaveBeenCalledTimes(2);
-    expect(mysql.query).toHaveBeenCalledWith(mockData.query);
+        expect(response).toEqual(mockData.queryResponse);
+    });
 
-    expect(response).toEqual(mockData.queryResponse);
-  });
+    it('should fail the first query and succeed on the second', async () => {
+        mysql.query.mockRejectedValueOnce(new Error(mockData.rejectError));
 
-  it("should fail the first query and return an error when the second query fails", async () => {
-    mysql.query.mockRejectedValueOnce(new Error(mockData.rejectError));
-    mysql.query.mockRejectedValueOnce(new Error(mockData.rejectError));
+        const response = await executeQuery(mockData.query);
 
-    const response = await executeQuery(mockData.query);
+        expect(mysql.query).toHaveBeenCalledTimes(2);
+        expect(mysql.query).toHaveBeenCalledWith(mockData.query);
 
-    expect(mysql.query).toHaveBeenCalledTimes(2);
-    expect(mysql.query).toHaveBeenCalledWith(mockData.query);
+        expect(response).toEqual(mockData.queryResponse);
+    });
 
-    expect(response).toEqual(mockData.errorMessage);
-  });
+    it('should fail the first query and return an error when the second query fails', async () => {
+        mysql.query.mockRejectedValueOnce(new Error(mockData.rejectError));
+        mysql.query.mockRejectedValueOnce(new Error(mockData.rejectError));
 
-  it("should end the connection", async () => {
-    await executeQuery(mockData.query);
+        const response = await executeQuery(mockData.query);
 
-    expect(mysql.end).toHaveBeenCalledTimes(1);
-    expect(mysql.end).toHaveBeenCalledWith();
-  });
+        expect(mysql.query).toHaveBeenCalledTimes(2);
+        expect(mysql.query).toHaveBeenCalledWith(mockData.query);
+
+        expect(response).toEqual(mockData.errorMessage);
+    });
+
+    it('should end the connection', async () => {
+        await executeQuery(mockData.query);
+
+        expect(mysql.end).toHaveBeenCalledTimes(1);
+        expect(mysql.end).toHaveBeenCalledWith();
+    });
 });

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,9 +1,9 @@
 module.exports = {
-    bracketSpacing: false,
+    bracketSpacing: true,
     jsxSingleQuote: true,
     printWidth: 120,
     trailingComma: 'es5',
     tabWidth: 4,
-    semi: false,
+    semi: true,
     singleQuote: true,
-}
+};

--- a/src/execute-query.js
+++ b/src/execute-query.js
@@ -1,32 +1,36 @@
-const mysql = require("serverless-mysql")({
-  config: {
-    host: process.env.host,
-    user: process.env.user,
-    password: process.env.password,
-    database: process.env.database
-  }
+const mysql = require('serverless-mysql')({
+    config: {
+        host: process.env.host,
+        user: process.env.user,
+        password: process.env.password,
+        database: process.env.database,
+    },
 });
 
-const executeQuery = async query => {
-  let response;
+const executeQuery = async (query, dbConfig) => {
+    if (dbConfig) {
+        mysql.config(dbConfig);
+    }
 
-  try {
-    response = await mysql.query(query);
-  } catch (ex) {
-    console.error("query failed: ", ex);
+    let response;
 
     try {
-      response = await mysql.query(query);
-    } catch (ex2) {
-      console.error("retried query failed: ", ex2);
+        response = await mysql.query(query);
+    } catch (ex) {
+        console.error('query failed: ', ex);
 
-      response = { error: `${ex2}` };
+        try {
+            response = await mysql.query(query);
+        } catch (ex2) {
+            console.error('retried query failed: ', ex2);
+
+            response = { error: `${ex2}` };
+        }
+    } finally {
+        await mysql.end();
+
+        return response;
     }
-  } finally {
-    await mysql.end();
-
-    return response;
-  }
 };
 
 export default executeQuery;


### PR DESCRIPTION
## Description

Adds the option to pass dbconfig values on the execute query call.

Adds Feature or Fixes: # (issue)

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in downstream modules
- [x] The test workflow is passing locally
