### PR TITLE
fix: disable husky install when doing semantic release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,3 +41,4 @@ jobs:
               run: npx semantic-release --branches master
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  HUSKY: "0" # disable husky installation for semantic release


### PR DESCRIPTION
Otherwise husky install fails with an obscure error about no .git directory existing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the publishing workflow configuration to optimize the release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->